### PR TITLE
Remove dependency to sources of validation-api

### DIFF
--- a/g-leaflet-mouseposition/pom.xml
+++ b/g-leaflet-mouseposition/pom.xml
@@ -148,12 +148,6 @@
             <artifactId>validation-api</artifactId>
             <version>1.0.0.GA</version>
         </dependency>
-        <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-            <version>1.0.0.GA</version>
-            <classifier>sources</classifier>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
I don't see the necessity in adding the sources of the dependency validation-api specifically as another dependency to this POM.

Furthermore, if I am not mistaken, validation-api itself is also not needed as a direct dependency. Both validation-api and its sources are dependencies of the used gwt-user, where they are marked as provided.

The problem in the current POM is that as both these dependencies are declared as compile dependencies, they will be packaged along with other dependencies, even though they are not needed at this point.